### PR TITLE
popover menu for managing DynamicRep settings for Notion page sets

### DIFF
--- a/MuscleMemory.xcodeproj/project.pbxproj
+++ b/MuscleMemory.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		B22E10F62D067E9A003F3D9F /* SearchUserPages.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22E10F52D067E89003F3D9F /* SearchUserPages.swift */; };
 		B22E10F72D067E9A003F3D9F /* SearchUserPages.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22E10F52D067E89003F3D9F /* SearchUserPages.swift */; };
 		B22E10F82D067E9A003F3D9F /* SearchUserPages.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22E10F52D067E89003F3D9F /* SearchUserPages.swift */; };
+		B25152BF2D54252E000ACE71 /* CustomPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25152BE2D542522000ACE71 /* CustomPopover.swift */; };
+		B25152C02D54252E000ACE71 /* CustomPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25152BE2D542522000ACE71 /* CustomPopover.swift */; };
+		B25152C12D54252E000ACE71 /* CustomPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25152BE2D542522000ACE71 /* CustomPopover.swift */; };
 		B25FEAD92D18E18500BF4FC7 /* ImportUserPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25FEAD82D18E17100BF4FC7 /* ImportUserPage.swift */; };
 		B25FEADA2D18E18500BF4FC7 /* ImportUserPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25FEAD82D18E17100BF4FC7 /* ImportUserPage.swift */; };
 		B25FEADB2D18E18500BF4FC7 /* ImportUserPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25FEAD82D18E17100BF4FC7 /* ImportUserPage.swift */; };
@@ -82,6 +85,7 @@
 		B22E10F12D04F7AF003F3D9F /* OAuthTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokens.swift; sourceTree = "<group>"; };
 		B22E10F52D067E89003F3D9F /* SearchUserPages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUserPages.swift; sourceTree = "<group>"; };
 		B248E14F2CE052DF005B9649 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B25152BE2D542522000ACE71 /* CustomPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPopover.swift; sourceTree = "<group>"; };
 		B25FEAD82D18E17100BF4FC7 /* ImportUserPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportUserPage.swift; sourceTree = "<group>"; };
 		B26842CE2CC704DB00471001 /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
 		B26842D22CC9F5FC00471001 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -173,6 +177,7 @@
 				B2B837C82BCB102F00BBC748 /* ImportedNotes.swift */,
 				5D1B7FA42C6CD75F00B474B0 /* NotionCall.swift */,
 				B26842CE2CC704DB00471001 /* MainMenu.swift */,
+				B25152BE2D542522000ACE71 /* CustomPopover.swift */,
 				B2B837C62BCB102F00BBC748 /* MuscleMemoryApp.swift */,
 				B2FF4B952CCD5C3A00A26EC7 /* NotionImportPageView.swift */,
 				B22E10F12D04F7AF003F3D9F /* OAuthTokens.swift */,
@@ -379,6 +384,7 @@
 				B26A46632CCFC4250064AF46 /* LaunchScreen.swift in Sources */,
 				B26842D12CC704DB00471001 /* MainMenu.swift in Sources */,
 				B22E10F02D04F723003F3D9F /* AuthBackend.swift in Sources */,
+				B25152C02D54252E000ACE71 /* CustomPopover.swift in Sources */,
 				B25FEADB2D18E18500BF4FC7 /* ImportUserPage.swift in Sources */,
 				B271C1902CD1CEC400710E70 /* NavPath.swift in Sources */,
 				B26A46672CD04C210064AF46 /* SignOutView.swift in Sources */,
@@ -401,6 +407,7 @@
 				B26A46652CCFC4250064AF46 /* LaunchScreen.swift in Sources */,
 				B26842CF2CC704DB00471001 /* MainMenu.swift in Sources */,
 				B22E10EE2D04F723003F3D9F /* AuthBackend.swift in Sources */,
+				B25152BF2D54252E000ACE71 /* CustomPopover.swift in Sources */,
 				B25FEAD92D18E18500BF4FC7 /* ImportUserPage.swift in Sources */,
 				B271C1922CD1CEC400710E70 /* NavPath.swift in Sources */,
 				B26A46682CD04C210064AF46 /* SignOutView.swift in Sources */,
@@ -433,6 +440,7 @@
 				5D1B7FA72C6CD75F00B474B0 /* NotionCall.swift in Sources */,
 				B2D220D12BD70B4500E55834 /* ImportedNotes.swift in Sources */,
 				B22E10F32D04F7C0003F3D9F /* OAuthTokens.swift in Sources */,
+				B25152C12D54252E000ACE71 /* CustomPopover.swift in Sources */,
 				B22E10EF2D04F723003F3D9F /* AuthBackend.swift in Sources */,
 				B26A466F2CD077950064AF46 /* LightDarkView.swift in Sources */,
 			);

--- a/MuscleMemory/CustomPopover.swift
+++ b/MuscleMemory/CustomPopover.swift
@@ -1,0 +1,25 @@
+//
+//  CustomPopover.swift
+//  MuscleMemory
+//
+//  Created by alex haidar on 2/5/25.
+//NOTE: nvm apple doesnt let us change the Menu {} style, we'll save this custom view for something else later on
+
+import SwiftUI
+import UIKit
+
+
+
+
+struct BlurView: UIViewRepresentable {
+   
+    func makeUIView(context: Self.Context) -> UIView {
+   
+        let effect = UIBlurEffect(style: .systemUltraThinMaterialDark)
+    let returnEffectView = UIVisualEffectView(effect: effect)
+    return returnEffectView
+    }
+   
+    func updateUIView(_ uiView:  UIView, context: Context ) {}
+}
+

--- a/MuscleMemory/MainMenu.swift
+++ b/MuscleMemory/MainMenu.swift
@@ -54,10 +54,10 @@ struct MainMenu: View {
                             .navigationBarBackButtonHidden(true)
                     } label: {
                         
-                        let emptyPage: String? = pageTitle.displaying?.plain_text //broke up expressions to resolve compile-time error 
+                        let emptyPage: String? = pageTitle.displaying?.plain_text     //broke up expressions to resolve compile-time error
                         let emptyEmojis: String? = pageTitle.emojis?.type
                         
-                        if let _emptyTab = emptyPage, emptyEmojis != nil {
+                        if let emptyTab = emptyPage, emptyEmojis != nil {
                             
                             ZStack(alignment: .center) {
                                 Rectangle()
@@ -65,7 +65,7 @@ struct MainMenu: View {
                                     .stroke(Color.white, lineWidth: 0.2)
                                     .foregroundStyle(Color.mmDark)
                                     .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.white, lineWidth: 0.2))
-                                    .opacity(0.1)
+                                    .opacity(0.8)
                                     .cornerRadius(10)
                                 
                                 
@@ -74,9 +74,30 @@ struct MainMenu: View {
                                 
                                 HStack(spacing: 20) {
                                     
-                                    Button(action: { }) { Image(systemName: "ellipsis")}      //TO-DO: prompt "DynamicRep" settings popover
-                                        .opacity(0.8)
-                                        .frame(width: 35, height: 35)
+                                   
+                                    
+                                    Menu {
+                                        Text("DynamicRep Settings \nfor \(emptyTab) ")
+                                        
+                                            .fontWeight(.medium)
+                                            .foregroundStyle(Color.white)
+                                            .opacity(0.5)
+                                        
+                                        Button("Live activities", systemImage: "clock.badge") {}
+                                       
+                                        Button(role: .destructive, action: {
+                                        }) { Label("Disable", systemImage: "multiply.circle")
+                                              
+                                        }
+                           
+                                            
+                                    } label: {
+                                        
+                                        Image(systemName: "ellipsis")}
+                                    .opacity(0.8)
+                                    .frame(width: 35, height: 35)
+                                    
+            
                                     
                                     if let emojis = pageTitle.emojis?.emoji, let title = pageTitle.displaying?.plain_text {
                                         Text("\(emojis)")
@@ -87,7 +108,7 @@ struct MainMenu: View {
                                         Rectangle()
                                             .cornerRadius(5)
                                             .frame(width: 150, height: 20)
-                                            .opacity(0.8)
+                                            .opacity(0.1)
                                         
                                     }
                                     
@@ -102,8 +123,7 @@ struct MainMenu: View {
                                 
                             }
                             .frame(width: 370, height: 57)
-                        }
-                        
+                         }
                     }
                 }
             }

--- a/MuscleMemory/MuscleMemoryApp.swift
+++ b/MuscleMemory/MuscleMemoryApp.swift
@@ -9,34 +9,39 @@ import SwiftUI
 import AuthenticationServices
 
 
-struct ContainerView: View {
+
     
     
-    @StateObject var navigationPath = NavPath.shared
     
-    var body: some View {
+    
+    struct ContainerView: View {
         
-        NavigationStack(path: $navigationPath.path) {
-            LaunchScreen()
-                .navigationDestination(for: NavPathItem.self) { navigationPathItem in
-                    switch navigationPathItem {
-                    case .home:
-                        MainMenu()
-                    case .settings:
-                        SettingsView()
-                    case .importPage:
-                        NotionImportPageView()
-                    case .logOut:
-                        SignOutView()
-                    case .appearence:
-                        LightDarkView()
-                    case .importpageUser:
-                        ImportedNotes()
+        
+        @StateObject var navigationPath = NavPath.shared
+        
+        var body: some View {
+            
+            NavigationStack(path: $navigationPath.path) {
+                LaunchScreen()
+                    .navigationDestination(for: NavPathItem.self) { navigationPathItem in
+                        switch navigationPathItem {
+                        case .home:
+                            MainMenu()
+                        case .settings:
+                            SettingsView()
+                        case .importPage:
+                            NotionImportPageView()
+                        case .logOut:
+                            SignOutView()
+                        case .appearence:
+                            LightDarkView()
+                        case .importpageUser:
+                            ImportedNotes()
+                        }
                     }
                 }
+            }
         }
-    }
-}
 
 @main
 struct MuscleMemoryApp: App {


### PR DESCRIPTION
A shortcut to the settings page to either disable DynamicRep flashcards for a particular notion page import set, or manage how often or time windows you want to receive these live activities. _ie you want to study a note set for a week, you configure these settings_
___
![CleanShot 2025-02-11 at 09 26 20@2x](https://github.com/user-attachments/assets/59016dd6-af4a-4a6f-9f6c-fd7e9b6275ff)
