### PR TITLE
support for lists and headings

### DIFF
--- a/Rep/NotionImportPageView.swift
+++ b/Rep/NotionImportPageView.swift
@@ -34,11 +34,11 @@ struct NotionImportPageView: View {
             ZStack(alignment: .center) {
                 
              
-                    Rectangle()
+                Rectangle()
                         .fill(Color.clear)
                         .frame(width: 370, height: 160)
-                        .glassEffect(.clear, in: .rect(cornerRadius: 30))
-                    
+                        .glassEffect(.regular, in: .rect(cornerRadius: 30))
+              
                 
                     
                    

--- a/Rep/SearchUserPages.swift
+++ b/Rep/SearchUserPages.swift
@@ -74,6 +74,8 @@ public class searchPages: ObservableObject {
     let searchEndpoint = URL(string: "https://api.notion.com/v1/search")
     private init() {}
     
+    
+    
     public func userEndpoint(modelContextTitle: ModelContext?) async throws {
         guard let url = searchEndpoint else { return }
         var request = URLRequest(url: url)
@@ -111,7 +113,7 @@ public class searchPages: ObservableObject {
             let text = getText?.title.first?.plain_text
             let emojis = title?.icon?.emoji
             let customType = title?.icon?.type
-        
+            
             let optionalEmoji = emojis ?? ""
            
             DispatchQueue.main.async {

--- a/Rep/UIComponents.swift
+++ b/Rep/UIComponents.swift
@@ -403,7 +403,7 @@ struct PaymentMenuCard: View {
             Rectangle()
                 .fill(Color.clear)
                 .frame(maxWidth: .infinity, maxHeight: 800)
-                .glassEffect(.clear, in: .rect(cornerRadius: 35))         ///glass background here
+                .glassEffect(.regular, in: .rect(cornerRadius: 35))         ///glass background here
                 
         }
     }


### PR DESCRIPTION
Heading block types and bulleted lists as well as numbered lists now parse into rep, the characters like notions special bullet point will not appear as those are special characters made available by notions UI renderer but text that are part of those block types will now appear.  