### PR TITLE
prevent syncing of deleted pages, General bug fixes

### DIFF
--- a/Rep.xcodeproj/project.pbxproj
+++ b/Rep.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		B2C2A9A72E87A9F000816A0B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B205A9582D73B62D00FFF047 /* WidgetKit.framework */; };
 		B2C2A9AA2E87A9F200816A0B /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2D220DD2BD981B800E55834 /* SwiftUI.framework */; };
 		B2C2A9AE2E88911A00816A0B /* DynamicRepExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B25A0A942D94FE3300420892 /* DynamicRepExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B2CDE6952F6383B600B33DA9 /* GlobalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2CDE6942F6383AD00B33DA9 /* GlobalHelpers.swift */; };
 		B2D362FF2E2C856400C3012C /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = B2D362FE2E2C855900C3012C /* .gitignore */; };
 		B2EC7FCE2E80C86100613126 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = B2EC7FCD2E80C86100613126 /* Supabase */; };
 		B2F82DAC2E9F330800006533 /* UIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F82DAB2E9F32F400006533 /* UIComponents.swift */; };
@@ -115,6 +116,7 @@
 		B2B837C62BCB102F00BBC748 /* RepApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepApp.swift; sourceTree = "<group>"; };
 		B2B837C82BCB102F00BBC748 /* ImportedNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportedNotes.swift; sourceTree = "<group>"; };
 		B2B837CA2BCB103000BBC748 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B2CDE6942F6383AD00B33DA9 /* GlobalHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalHelpers.swift; sourceTree = "<group>"; };
 		B2D220DD2BD981B800E55834 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		B2D362FE2E2C855900C3012C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		B2F82DAB2E9F32F400006533 /* UIComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIComponents.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				B26D98A82EE26CDB003DEA64 /* StoreKitTestCertificate.cer */,
 				B2575D102EE269B500B82793 /* Rep pro tier.storekit */,
 				B24A69832F57D97D00FBB5FB /* tosPage.swift */,
+				B2CDE6942F6383AD00B33DA9 /* GlobalHelpers.swift */,
 				B2575D0C2EE120D900B82793 /* PaymentStore.swift */,
 				B2F82DAB2E9F32F400006533 /* UIComponents.swift */,
 				B205064F2D98A3CC0082FEA2 /* LocalCache.swift */,
@@ -350,6 +353,7 @@
 				B26842D12CC704DB00471001 /* MainMenu.swift in Sources */,
 				B2575D0D2EE120E200B82793 /* PaymentStore.swift in Sources */,
 				B2F82DAC2E9F330800006533 /* UIComponents.swift in Sources */,
+				B2CDE6952F6383B600B33DA9 /* GlobalHelpers.swift in Sources */,
 				B22E10F02D04F723003F3D9F /* AuthBackend.swift in Sources */,
 				B20506502D98A3E50082FEA2 /* LocalCache.swift in Sources */,
 				B271C1902CD1CEC400710E70 /* NavPath.swift in Sources */,

--- a/Rep.xcodeproj/xcuserdata/alexhaidar.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Rep.xcodeproj/xcuserdata/alexhaidar.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "4C9F19C6-67F6-42E1-BC15-F2D4AB1DE72D"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "DDF8DF25-B27B-4D8E-B0A8-32D3A272612F"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Rep/ImportUserPage.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "129"
+            endingLineNumber = "129"
+            landmarkName = "pageEndpoint(pageID:context:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/Rep/DynamicRepControlsView.swift
+++ b/Rep/DynamicRepControlsView.swift
@@ -116,25 +116,27 @@ struct DynamicRepControlsView: View {
                 let rows: Int = 5
                 let base = basePerPage
                 
-                for i in stride(from: 0, to: queryID.count, by: rows) {
-                    
-                    if Task.isCancelled { return }
-                    print("prev task cancelled")
-                    
-                    let stagger = (i / rows) + 1
-                    let scaledOffsets = staggerDateComponents(components: selectedOption.interval, multiplier: stagger)
-                    
-                    let computedOffset: Date? = selectedOption.label == "Off" ? nil : Calendar.current.date(byAdding: scaledOffsets, to: base)
-                    
-                    let batch = min(i + rows, queryID.count)
-                    let idsPerBatch = Array(queryID[i..<batch])
-                    
-                    do {
-                        let send = try await supabaseDBClient.from("push_tokens").update(["offset_date" : computedOffset]).in("id", values: idsPerBatch).in("page_id", values: [pageID]).execute()
-                        print("OFFSET DATE SENT TO SUPABASE: \(send)")
-                        print("page ids here: \(pageID)")
-                    } catch {
-                        print("failed to send offset timestamps to supabase ❗️: \(error.localizedDescription)")
+                Task.detached(priority: .background) {
+                    for i in stride(from: 0, to: queryID.count, by: rows) {
+                        
+                        if Task.isCancelled { return }
+                        print("prev task cancelled")
+                        
+                        let stagger = (i / rows) + 1
+                        let scaledOffsets = staggerDateComponents(components: selectedOption.interval, multiplier: stagger)
+                        
+                        let computedOffset: Date? = selectedOption.label == "Off" ? nil : Calendar.current.date(byAdding: scaledOffsets, to: base)
+                        
+                        let batch = min(i + rows, queryID.count)
+                        let idsPerBatch = Array(queryID[i..<batch])
+                        
+                        do {
+                            let send = try await supabaseDBClient.from("push_tokens").update(["offset_date" : computedOffset]).in("id", values: idsPerBatch).in("page_id", values: [pageID]).execute()
+                            print("OFFSET DATE SENT TO SUPABASE: \(send)")
+                            print("page ids here: \(pageID)")
+                        } catch {
+                            print("failed to send offset timestamps to supabase ❗️: \(error.localizedDescription)")
+                        }
                     }
                 }
             } catch {

--- a/Rep/GlobalHelpers.swift
+++ b/Rep/GlobalHelpers.swift
@@ -1,0 +1,22 @@
+//
+//  GlobalHelpers.swift
+//  Rep
+//
+//  Created by alex haidar on 3/13/26.
+//TODO: move all global helper functions across the code base into here 
+import Foundation
+import SwiftData
+
+
+@MainActor
+ func fetchSyncPg(pageID: String, context: ModelContext) throws -> NotionPageMetaData? {          ///query synced page
+   let fetchSyncPg = FetchDescriptor<NotionPageMetaData>(predicate: #Predicate {$0.pageID == pageID})
+   print("all ids: \(pageID)")
+   return try context.fetch(fetchSyncPg).first
+}
+
+@MainActor
+public func fetchPg(pageID: String, context: ModelContext) throws -> UserPageTitle? {                     ///query un-synced page
+   let fetchPg = FetchDescriptor<UserPageTitle>(predicate: #Predicate { $0.titleID == pageID })
+   return try context.fetch(fetchPg).first
+}

--- a/Rep/ImportUserPage.swift
+++ b/Rep/ImportUserPage.swift
@@ -97,18 +97,6 @@ let supabaseDBClient = SupabaseClient(supabaseURL: URL(string: "https://oxgumwqx
     }
 }
 
-@Model final class DeletedPage {
-    @Attribute(.unique) var pageID: String
-    var deletedAt: Date = Date()
-    init(pageID: String) { self.pageID = pageID }
-}
-
-@MainActor
-func isPageDeleted(_ pageID: String, in context: ModelContext) throws -> Bool {
-    let desc = FetchDescriptor<DeletedPage>(predicate: #Predicate { $0.pageID == pageID })
-    return try context.fetch(desc).first != nil
-}
-
 
 @MainActor
 class ImportUserPage: ObservableObject {
@@ -135,8 +123,14 @@ class ImportUserPage: ObservableObject {
     var userPageId: String?
     var storePageIDSets: Set<String> = []
     
-    
+
     public func pageEndpoint(pageID: String, context: ModelContext) async throws {
+        
+        let deleted = try isPageDeleted(pageID, in: context)
+        if deleted {
+            print("deleted")
+            return
+        }
         
         let pageID = pageID
         let pagesEndpoint = "https://api.notion.com/v1/blocks/"
@@ -276,22 +270,24 @@ class ImportUserPage: ObservableObject {
                 let pageID = pageID
                 storePageIDSets.insert(pageID)
                 
-                for row in chunkedRows {
-                    print("did content change?: \(row)")
-                    
-                    let hashContent = SHA256.hash(data: row.data(using: .utf8)!).map{String(format: "%02x", $0)}.joined()
-                    
-                    do {
-                        guard let token = formattedTokenString else { continue }
-                        guard !row.isEmpty || !pageID.isEmpty else { continue }
+                Task.detached(priority: .background) {
+                    for row in chunkedRows {
+                        print("did content change?: \(row)")
                         
-                        let pushAndPageData = PushToSupabase(token: token, page_data: row, page_id: pageID, page_title: SendTitle.shareTitle.displayTitle, content_hash: hashContent)
-                        let sendID = try await supabaseDBClient.from("push_tokens").upsert([pushAndPageData], onConflict: "page_id, content_hash").select("token, page_id, content_hash, page_data, page_title").execute()
+                        let hashContent = SHA256.hash(data: row.data(using: .utf8)!).map{String(format: "%02x", $0)}.joined()
                         
-                        Logger().log("page_id successfully sent up to Supabase: \(String(describing:(sendID)))")
-                        
-                    } catch {
-                        print("supabse insertion errror ❗️\(error.localizedDescription)")
+                        do {
+                            guard let token = formattedTokenString else { continue }
+                            guard !row.isEmpty || !pageID.isEmpty else { continue }
+                            
+                            let pushAndPageData = PushToSupabase(token: token, page_data: row, page_id: pageID, page_title: SendTitle.shareTitle.displayTitle, content_hash: hashContent)
+                            let sendID = try await supabaseDBClient.from("push_tokens").upsert([pushAndPageData], onConflict: "page_id, content_hash").select("token, page_id, content_hash, page_data, page_title").execute()
+                            
+                            Logger().log("page_id successfully sent up to Supabase: \(String(describing:(sendID)))")
+                            
+                        } catch {
+                            print("supabse insertion errror ❗️\(error.localizedDescription)")
+                        }
                     }
                 }
                 

--- a/Rep/Info.plist
+++ b/Rep/Info.plist
@@ -5,6 +5,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>MuscleMemory.KimchiLabs.com</string>
+		<string>MuscleMemory.KimchiLabs.com.supabase</string>
 	</array>
 	<key>CFBundleURLTypes</key>
 	<array>

--- a/Rep/MainMenu.swift
+++ b/Rep/MainMenu.swift
@@ -136,7 +136,7 @@ struct MainMenu: View {
                                     .padding(.trailing, 3)
                                 
                                 
-                                let time: Date = LastEdited.shared.lastEditedAt ?? Date()
+                                let time: Date = LastEdited.shared.lastFetchedAt ?? Date()
                                 
                                 Text(time.formatted(.dateTime.weekday().day().hour().minute()))
                                     .font(.system(size: 10))

--- a/Rep/RepApp.swift
+++ b/Rep/RepApp.swift
@@ -51,7 +51,7 @@ struct MuscleMemoryApp: App {
         }
     }
     
-    let centralContainer = try! ModelContainer(for: UserEmail.self, UserPageTitle.self, UserPageContent.self, AuthToken.self, SyncUserContentPage.self, NotionPageMetaData.self)
+    let centralContainer = try! ModelContainer(for: UserEmail.self, UserPageTitle.self, UserPageContent.self, AuthToken.self, SyncUserContentPage.self, NotionPageMetaData.self, DeletedPage.self)
    
     @AppStorage("appearence.toggle") private var toggleEnabled = false
         
@@ -84,6 +84,13 @@ struct MuscleMemoryApp: App {
                                         let pageId = try context!.fetch(desc)
                                         
                                         for pg in pageId {
+                                            
+                                            let deleted = try isPageDeleted(pg.pageID, in: context!)
+                                            if deleted {
+                                                print("deleted")
+                                                continue
+                                            }
+                                            
                                             try await ImportUserPage.shared.pageEndpoint(pageID: pg.pageID, context: context!)
                                         }
                                     }
@@ -103,6 +110,15 @@ struct MuscleMemoryApp: App {
                                     let pageId = try context!.fetch(desc)
                                     print("page schemas \(pageId.count)")
                                     for pg in pageId {
+                                       
+                                        let deleted = try isPageDeleted(pg.pageID, in: context!)
+                                        if deleted {
+                                            print("deleted")
+                                            continue
+                                        }
+                                          
+                                        
+                                        
                                         try await ImportUserPage.shared.pageEndpoint(pageID: pg.pageID, context: context!)
                                         print("page id: \(pg.pageID)")
                                     }

--- a/Rep/SearchUserPages.swift
+++ b/Rep/SearchUserPages.swift
@@ -51,6 +51,7 @@ final class SendTitle {                     ///so page title can be sent to supa
 
 final class LastEdited: ObservableObject {
     @Published var lastEditedAt: Date?
+    @Published var lastFetchedAt: Date?
     static let shared = LastEdited()
 }
 
@@ -64,6 +65,7 @@ final class LastEdited: ObservableObject {
     var isAutoSync: Bool
     var plain_text: String
     
+    
     init(pageID: String, pageTitle: String, lastEditedAt: Date, lastFetchedAt: Date, isAutoSync: Bool, plain_text: String) {
         self.pageID = pageID
         self.pageTitle = pageTitle
@@ -75,16 +77,30 @@ final class LastEdited: ObservableObject {
 }
 
 
+@Model final class DeletedPage {
+    @Attribute(.unique) var pageID: String
+    var deletedAt: Date = Date()
+    init(pageID: String) { self.pageID = pageID }
+}
+
+@MainActor
+func isPageDeleted(_ pageID: String, in context: ModelContext) throws -> Bool {
+    let desc = FetchDescriptor<DeletedPage>(predicate: #Predicate { $0.pageID == pageID })
+    return try context.fetch(desc).first != nil
+    
+}
+
+
 @MainActor
 public class searchPages: ObservableObject {
     
-    public static let shared = searchPages()
+    public static let shared = searchPages(id: "")
     
     @Published var emojis: NotionSearchRequest.Icon?
     @Published var displaying: NotionSearchRequest.TitleItem?
     @Published var userBlocks: NotionSearchRequest.result?
     
-    @Published var id: String?
+    @Published var id: String
     @Published var icon: String?
     @Published var plain_text: String?
     @Published var emoji: String?
@@ -102,37 +118,23 @@ public class searchPages: ObservableObject {
         return token
     }
     
-    func fetchSyncPg(pageID: String, context: ModelContext) throws -> NotionPageMetaData? {          ///query synced page
-        
-        let fetchSyncPg = FetchDescriptor<NotionPageMetaData>(predicate: #Predicate { $0.pageID == pageID })
-        return try context.fetch(fetchSyncPg).first
-    }
-    
-    
-    func fetchPg(pageID: String, context: ModelContext) throws -> UserPageTitle? {                     ///query un-synced page
-        
-        let fetchPg = FetchDescriptor<UserPageTitle>(predicate: #Predicate { $0.titleID == pageID })
-        return try context.fetch(fetchPg).first
-    }
-    
     let searchEndpoint = URL(string: "https://api.notion.com/v1/search")
-    private init() {}
+    private init(id: String) {
+        self.id = id
+    }
     
-    private func getPageData(text: String?, customType: String?, optionalEmoji: String, pageID: String, accessObject: String?, context: ModelContext) throws {
+    private func getPageData(text: String?, customType: String?, optionalEmoji: String, pageID: String, accessObject: String?, context: ModelContext, existingTab: NotionPageMetaData) throws {
         
-        
-        DispatchQueue.main.async {
-            if let titles = text {
-                
-                self.displaying = NotionSearchRequest.TitleItem(plain_text: titles)
-                print("being passed to main thread: \(titles)")
-            } else {
-                print("plain text is not being run on main")
-            }
+        if let titles = text {
             
-            self.emojis = NotionSearchRequest.Icon(type: customType ?? "", emoji: optionalEmoji)
-            print("emoji has been stored🫡\(optionalEmoji)")
+            self.displaying = NotionSearchRequest.TitleItem(plain_text: titles)
+            print("being passed to main thread: \(titles)")
+        } else {
+            print("plain text is not being run on main")
         }
+        
+        self.emojis = NotionSearchRequest.Icon(type: customType ?? "", emoji: optionalEmoji)
+        print("emoji has been stored🫡\(optionalEmoji)")
         
         
         if let objectBlocks = accessObject, let displayTitle = text {
@@ -142,27 +144,28 @@ public class searchPages: ObservableObject {
             print("emoji from title:\(optionalEmoji)")
             
             
+            let pageTitle = displayTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !pageTitle.isEmpty else { return }
+            
+            SendTitle.shareTitle.displayTitle = pageTitle
+            
             if SyncController.shared.isAutoSync {
-                if let existingTab = try fetchSyncPg(pageID: pageID, context: context) {        ///synced path
-                    
-                    existingTab.pageTitle = displayTitle
-                    existingTab.plain_text = objectBlocks
-                    try context.save()
-                    
-                    let storeSyncTitle = UserPageTitle(titleID: pageID, icon: customType, plain_text: displayTitle, emoji: optionalEmoji)
-                    context.insert(storeSyncTitle)
-                    try context.save()
-                    
-                    SendTitle.shareTitle.displayTitle = displayTitle
-                }
+                existingTab.pageTitle = pageTitle
+                existingTab.plain_text = objectBlocks
+            }
+            
+            if let existingTabSync = try fetchPg(pageID: pageID, context: context) {        ///upsert
+                existingTabSync.plain_text = pageTitle
+                existingTabSync.icon = customType
+                existingTabSync.emoji = optionalEmoji
             } else {
-                if try fetchPg(pageID: pageID, context: context) == nil {                   ///non-syned path
-                    let storedTitle = UserPageTitle(titleID: pageID, icon: customType, plain_text: displayTitle, emoji: optionalEmoji)
-                    context.insert(storedTitle)
-                    try context.save()
-                    
-                    SendTitle.shareTitle.displayTitle = displayTitle
-                }
+                let storedTitle = UserPageTitle(        ///insert
+                    titleID: pageID,
+                    icon: customType,
+                    plain_text: pageTitle,
+                    emoji: optionalEmoji
+                )
+                context.insert(storedTitle)
             }
         } else {
             print("an object is not being stored")
@@ -171,6 +174,19 @@ public class searchPages: ObservableObject {
     
     
     public func userEndpoint(context: ModelContext) async throws {
+        
+        let fetch = FetchDescriptor<NotionPageMetaData>()
+        let page = try context.fetch(fetch)
+        
+        for pg in page {
+            let deleted = try isPageDeleted(pg.pageID, in: context)
+            print("deleted result:", deleted)
+            
+            if deleted {
+                print("skipped!")
+                continue
+            }
+        }
         
         guard let url = searchEndpoint else { return }
         var request = URLRequest(url: url)
@@ -193,12 +209,12 @@ public class searchPages: ObservableObject {
                 throw URLError(.badServerResponse)
             }
             
+            
             if let dataString = String(data: userData, encoding: .utf8) {
                 print("EVERYTHING BELOW HERE IS USER ENDPOINT RESPONSE: \(dataString)")
             } else {
                 print("empty data string")
             }
-            
             
             let decodePageData = JSONDecoder()
             decodePageData.dateDecodingStrategy = .custom { decoder in
@@ -214,19 +230,27 @@ public class searchPages: ObservableObject {
                 format.formatOptions = [.withInternetDateTime]
                 if let dateTime = format.date(from: dateString) { return dateTime }
                 
-                throw DecodingError.typeMismatch(Date.self,
-                                                 DecodingError.Context(codingPath: c.codingPath,
-                                                                       debugDescription: "Date string does not match expected format"))
+                throw DecodingError.typeMismatch(Date.self, DecodingError.Context(codingPath: c.codingPath,
+                                                                                  debugDescription: "Date string does not match expected format"))
             }
             
             let decodedPageStrings = try decodePageData.decode(NotionSearchRequest.self, from: userData)
             
             for page in decodedPageStrings.results {
                 guard let pageID = page.id else { continue }
-                
+  
                 if try isPageDeleted(pageID, in: context) {
+                    if let deleteMeta = try fetchSyncPg(pageID: pageID, context: context) {
+                        context.delete(deleteMeta)
+                    }
+                    
+                    if let deleteMeta = try fetchPg(pageID: pageID, context: context) {
+                        context.delete(deleteMeta)
+                    }
+                    print("deleted page data 🗑️")
                     continue
                 }
+                
                 
                 let lastEdited = page.last_edited_time
                 print("LAST EDITED AT: \(lastEdited ?? Date())")
@@ -236,45 +260,41 @@ public class searchPages: ObservableObject {
                 }
                 
                 let getText = page.properties?.title
-                let text = getText?.title.first?.plain_text
-                let emojis = page.icon?.emoji
-                let customType = page.icon?.type
+                let text: String? = getText?.title.first?.plain_text
+                let emojis: String? = page.icon?.emoji
+                let customType: String? = page.icon?.type
                 let optionalEmoji = emojis ?? ""
                 let syncedPageID = pageID
                 
                 
                 guard let notionLastEditedTime = lastEdited else { continue }
-                
                 if let existingPageSync = try fetchSyncPg(pageID: syncedPageID, context: context) {     ///sync path to update existing page
                     
-                    if notionLastEditedTime > existingPageSync.lastFetchedAt {
-                        print("LAST EDITED: \(existingPageSync.lastEditedAt)", "|", "LAST FETCHED: \(existingPageSync.lastFetchedAt)")
-                        
-                        try getPageData(text: text, customType: customType, optionalEmoji: optionalEmoji, pageID: pageID, accessObject: text, context: context)
-                        
-                    } else {
-                        continue
+                    await MainActor.run {
+                        LastEdited.shared.lastFetchedAt = existingPageSync.lastFetchedAt
                     }
+                    
+                    print("LAST EDITED: \(existingPageSync.lastEditedAt)", "|", "LAST FETCHED: \(existingPageSync.lastFetchedAt)")
+                    try getPageData(text: text, customType: customType, optionalEmoji: optionalEmoji, pageID: pageID, accessObject: text, context: context, existingTab: existingPageSync)
+                    
                     existingPageSync.lastEditedAt = notionLastEditedTime
                     existingPageSync.lastFetchedAt = Date()
-                    try context.save()
                     
                 } else {
                     
-                    let firstTimePageSync = NotionPageMetaData(pageID: pageID, pageTitle: text!, lastEditedAt: notionLastEditedTime, lastFetchedAt: .distantPast, isAutoSync: true, plain_text: text ?? "")     ///sync path for page being imported for the first time
+                    let firstTimePageSync = NotionPageMetaData(pageID: pageID, pageTitle: text ?? "", lastEditedAt: notionLastEditedTime, lastFetchedAt: .distantPast, isAutoSync: true, plain_text: text ?? "")     ///sync path for page being imported for the first time
                     context.insert(firstTimePageSync)
                     
-                    if notionLastEditedTime <= firstTimePageSync.lastFetchedAt { continue }
-                    
-                    try getPageData(text: text, customType: customType, optionalEmoji: optionalEmoji, pageID: pageID, accessObject: text, context: context)
+                    try getPageData(text: text, customType: customType, optionalEmoji: optionalEmoji, pageID: pageID, accessObject: text, context: context, existingTab: firstTimePageSync)
                     print("TEXT TILE FIRST: \(text ?? "EMPTY")")
                     
                     firstTimePageSync.lastEditedAt = notionLastEditedTime
                     firstTimePageSync.lastFetchedAt = Date()
-                    try context.save()
                     
                 }
             }
+            try context.save()
+            
         } catch {
             print("bad response")
             if let decodeBlocksError = error as? DecodingError {

--- a/Rep/SyncController.swift
+++ b/Rep/SyncController.swift
@@ -44,11 +44,13 @@ final class BackgroundRefresh {
             for pg in pageID {
                 try await ImportUserPage.shared.pageEndpoint(pageID: pg.pageID, context: context)
             }
-            
+ 
             print("sync task ran successfully 🔄")
         } catch {
             print("auto sync task error: \(error)")
         }
+        try await Task.sleep(for: .seconds(60))
+        print("...sleeping")
     }
     
     private var autoSyncTask: Task<Void, Never>?
@@ -57,7 +59,7 @@ final class BackgroundRefresh {
     func startAutoSyncTask(pages: ModelContext, context: ModelContext) {
         
         if SyncController.shared.isAutoSync {
-            autoSyncTask = Task { @MainActor in
+            autoSyncTask = Task {
                 while !Task.isCancelled {
                     do {
                         try await runSyncWhenReady(context: context, pages: pages)
@@ -88,11 +90,12 @@ final class BackgroundRefresh {
         }
     }
     
+    enum TaskRegister {         ///add more tasks for future bg capabilities  here
+        static let syncIdentifier: String = "MuscleMemory.KimchiLabs.com"
+    }
     
     static func bgTaskRegister() {
-        
-        let identifier: String = "MuscleMemory.KimchiLabs.com"
-        BGTaskScheduler.shared.register(forTaskWithIdentifier: identifier, using: nil) { task in
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: TaskRegister.syncIdentifier, using: nil) { task in
             guard let task = task as? BGAppRefreshTask else { return }
             
             BackgroundRefresh.shared.bgAppRefresh(task: task)
@@ -100,11 +103,11 @@ final class BackgroundRefresh {
     }
     
     static func bgTaskRequest() {
-        let taskRequest = BGAppRefreshTaskRequest(identifier: "MuscleMemory.KimchiLabs.com")
-        taskRequest.earliestBeginDate = Date(timeIntervalSinceNow: 60)
+        let taskSyncRequest = BGAppRefreshTaskRequest(identifier: "MuscleMemory.KimchiLabs.com")
+        taskSyncRequest.earliestBeginDate = Date(timeIntervalSinceNow: 60)
         
         do {
-            try BGTaskScheduler.shared.submit(taskRequest)
+            try BGTaskScheduler.shared.submit(taskSyncRequest)
         } catch {
             print("task request error ❗️: \(error)")
         }


### PR DESCRIPTION
What changed 
---
- new file for all the global helper functions where everything will be moved into
- syncing and resurrection of deleted tabs/pages was fixed with the `isPageDeleted` helper function call, 
   was previously failing due to `DeletedPages` not being included in the SwiftData model container by accident
 - list rendering and other supabase calling actions are much faster by using background tasks