### PR TITLE
Airdrop button, chat dialog performance improvements, UI tweaks

### DIFF
--- a/Rep/ImportedNotes.swift
+++ b/Rep/ImportedNotes.swift
@@ -143,20 +143,26 @@ struct ImportedNotes: View {
                                 }
                             }
                         } else {
-                            List(pageBlocks, id: \.self) { block in
-                                Text(block.userContentPage?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
+                            let noteText = pageBlocks
+                                .compactMap { $0.userContentPage?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                                .filter { !$0.isEmpty }
+                                .joined(separator: "\n\n")
+                            ScrollView {
+                                Text(noteText)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.leading)
                                     .font(.system(size: 16)).lineSpacing(5)
-                                    .listRowBackground(Color.mmBackground)
-                                    .listRowSeparator(.hidden)
                                     .multilineTextAlignment(.leading)
                                     .textSelection(.enabled)
+                                    .tint(.white)
                                     .padding(.trailing)
+                                    .padding(.top)
+                                Spacer().frame(height: 30)
                             }
-                            .listStyle(.plain)
                         }
                     case .openaiChatContent(let openaiChatContent):
-                        let chatLines = openaiChatContent.content.components(separatedBy: .newlines).map{ $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
-                        if chatLines.isEmpty {
+                        let chatText = openaiChatContent.content.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if chatText.isEmpty {
                             VStack(spacing: -10) {
                                 ForEach(0..<13) { _ in
                                     SkeletonLoader()
@@ -164,67 +170,64 @@ struct ImportedNotes: View {
                             }
                         } else {
                             ScrollView {
-                                ForEach(chatLines, id: \.self) { line in
-                                    Text(line)
+                                Text(chatText)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.leading)
+                                    .font(.system(size: 16)).lineSpacing(2).fontWeight(.medium)
+                                    .lineLimit(nil)
+                                    .lineHeight(.loose)
+                                    .textSelection(.enabled)
+                                    .tint(.white)
+                                    .padding(.trailing)
+                                    .padding(.top)
+                                Spacer().frame(height: 30)
+                            }
+                        }
+                    case .repDesktopTranscription(let repDesktopTranscription):
+                        let noteText = repDesktopTranscription.fullNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let transcriptText = repDesktopTranscription.fullTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if transcriptText.isEmpty || noteText.isEmpty {
+                            VStack(spacing: -10) {
+                                ForEach(0..<13) { _ in
+                                    SkeletonLoader()
+                                }
+                            }
+                        } else {
+                            ScrollView {
+                                if selectedTab == .notes {
+                                    Text(noteText)
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                         .padding(.leading)
                                         .font(.system(size: 16)).lineSpacing(2).fontWeight(.medium)
                                         .lineLimit(nil)
                                         .lineHeight(.loose)
                                         .textSelection(.enabled)
+                                        .tint(.white)
                                         .padding(.trailing)
                                         .padding(.top)
-                                }
-                                Spacer().frame(height: 30)
-                            }
-                        }
-                    case .repDesktopTranscription(let repDesktopTranscription):
-                        let noteLines = repDesktopTranscription.fullNotes.components(separatedBy: .newlines).map{ $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
-                        let transcriptLines = repDesktopTranscription.fullTranscript.components(separatedBy: .newlines).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter{ !$0.isEmpty }
-                        if transcriptLines.isEmpty || noteLines.isEmpty {
-                            VStack(spacing: -10) {
-                                ForEach(0..<13) { _ in
-                                    SkeletonLoader()
-                                }
-                            }
-                        } else {
-                            ScrollView {
-                                if selectedTab == .notes {
-                                    ForEach(noteLines, id: \.self) { line in
-                                        Text(line)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.leading)
-                                            .font(.system(size: 16)).lineSpacing(2).fontWeight(.medium)
-                                            .lineLimit(nil)
-                                            .lineHeight(.loose)
-                                            .textSelection(.enabled)
-                                            .padding(.trailing)
-                                            .padding(.top)
-                                    }
                                     Spacer().frame(height: 50)
                                 }
                                 
                                 if selectedTab == .transcript {
-                                    ForEach(transcriptLines, id: \.self) { line in
-                                        Text(line)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.leading)
-                                            .font(.system(size: 16)).lineSpacing(1).fontWeight(.regular).fontDesign(.monospaced)
-                                            .lineLimit(nil)
-                                            .lineHeight(.loose)
-                                            .textSelection(.enabled)
-                                            .padding(.trailing)
-                                            .padding(.top)
-                                            .opacity(0.5)
-                                    }
+                                    Text(transcriptText)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.leading)
+                                        .font(.system(size: 16)).lineSpacing(1).fontWeight(.regular).fontDesign(.monospaced)
+                                        .lineLimit(nil)
+                                        .lineHeight(.loose)
+                                        .textSelection(.enabled)
+                                        .tint(.white)
+                                        .padding(.trailing)
+                                        .padding(.top)
+                                        .opacity(0.5)
                                     Spacer().frame(height: 50)
                                 }
                             }
                         }
                     case .repMobileTranscription(let repMobileTranscription):
-                        let noteLines = repMobileTranscription.fullNotes.components(separatedBy: .newlines).map{ $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
-                        let transcriptLines = repMobileTranscription.fullTranscript.components(separatedBy: .newlines).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter{ !$0.isEmpty }
-                        if noteLines.isEmpty || transcriptLines.isEmpty {
+                        let noteText = repMobileTranscription.fullNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let transcriptText = repMobileTranscription.fullTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if noteText.isEmpty || transcriptText.isEmpty {
                             VStack(spacing: -10) {
                                 ForEach(0..<13) { _ in
                                     SkeletonLoader()
@@ -233,33 +236,31 @@ struct ImportedNotes: View {
                         } else {
                             ScrollView {
                                 if selectedTab == .notes {
-                                    ForEach(noteLines, id: \.self) { line in
-                                        Text(line)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.leading)
-                                            .font(.system(size: 16)).lineSpacing(2).fontWeight(.medium)
-                                            .lineLimit(nil)
-                                            .lineHeight(.loose)
-                                            .textSelection(.enabled)
-                                            .padding(.trailing)
-                                            .padding(.top)
-                                    }
+                                    Text(noteText)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.leading)
+                                        .font(.system(size: 16)).lineSpacing(2).fontWeight(.medium)
+                                        .lineLimit(nil)
+                                        .lineHeight(.loose)
+                                        .textSelection(.enabled)
+                                        .tint(.white)
+                                        .padding(.trailing)
+                                        .padding(.top)
                                     Spacer().frame(height: 50)
                                 }
                                 
                                 if selectedTab == .transcript {
-                                    ForEach(transcriptLines, id: \.self) { line in
-                                        Text(line)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.leading)
-                                            .font(.system(size: 16)).lineSpacing(1).fontWeight(.regular).fontDesign(.monospaced)
-                                            .lineLimit(nil)
-                                            .lineHeight(.loose)
-                                            .textSelection(.enabled)
-                                            .padding(.trailing)
-                                            .padding(.top)
-                                            .opacity(0.5)
-                                    }
+                                    Text(transcriptText)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.leading)
+                                        .font(.system(size: 16)).lineSpacing(1).fontWeight(.regular).fontDesign(.monospaced)
+                                        .lineLimit(nil)
+                                        .lineHeight(.loose)
+                                        .textSelection(.enabled)
+                                        .tint(.white)
+                                        .padding(.trailing)
+                                        .padding(.top)
+                                        .opacity(0.5)
                                     Spacer().frame(height: 50)
                                 }
                             }
@@ -437,5 +438,4 @@ extension CombinedDataSource {
         )
     )
 }
-
 

--- a/Rep/UIComponents/ChatView.swift
+++ b/Rep/UIComponents/ChatView.swift
@@ -26,9 +26,8 @@ struct ChatView: View {
     @State private var isCircleVisible: Bool = false
     @State private var isCirclePulsing: Bool = false
     @State var showEmptyState: Bool = false
-
+    @State var task: Task<Void, Never>?
     @FocusState private var isChatFocused: Bool
-    
     @AppStorage("hasSeenEmptyState") var isEmptyStateSeen: Bool = false
 
 
@@ -51,7 +50,7 @@ struct ChatView: View {
                                     .opacity(isCirclePulsing ? 0.8 : 0.25)
                                     .fontDesign(.rounded)
                                     .fontWeight(.medium)
-                                    
+                                
                                 
                                 Spacer()
                             }
@@ -76,6 +75,7 @@ struct ChatView: View {
                                 .lineLimit(nil)
                                 .transition(.opacity.combined(with: .blurReplace))
                                 .textSelection(.enabled)
+                                .tint(.white)
                         }.animation(.easeOut(duration: 0.3), value: Chat.shared.responseMessage.count)
                         
                         Spacer(minLength: keyboardHeight > 0 ? keyboardHeight + 150 : 135)
@@ -86,10 +86,15 @@ struct ChatView: View {
                     
                 }.frame(maxWidth: .infinity, alignment: .leading)
                     .onChange(of: Chat.shared.responseMessage.last?.text) { _, _ in
-                        Task { @MainActor in
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                proxy.scrollTo("chat-bottom", anchor: .bottom)
-                            }
+                        
+                        guard task == nil else { return }
+                        
+                        task = Task { @MainActor in
+                            guard !Task.isCancelled else { return }
+                            
+                            try? await Task.sleep(for: .milliseconds(300))
+                            proxy.scrollTo("chat-bottom", anchor: .bottom)
+                            task = nil
                         }
                     }
                 }

--- a/Rep/UIComponents/ChatView.swift
+++ b/Rep/UIComponents/ChatView.swift
@@ -23,8 +23,8 @@ struct ChatView: View {
     @State public var isNewChat: Bool = false
     @State var isGenerating: Bool = false
     @State private var keyboardHeight: CGFloat = 0
-    @State private var isCircleVisible: Bool = false
-    @State private var isCirclePulsing: Bool = false
+    @State private var isShimmerTextVisible: Bool = false
+    @State private var isTextShimmering: Bool = false
     @State var showEmptyState: Bool = false
     @State var task: Task<Void, Never>?
     @FocusState private var isChatFocused: Bool
@@ -39,33 +39,6 @@ struct ChatView: View {
                     VStack {
                         Spacer(minLength: 65)
                         
-                        if isCircleVisible {
-                            HStack(alignment: .top, spacing: 10) {
-                                Circle()
-                                    .frame(width: 18, height: 18)
-                                    .opacity(isCirclePulsing ? 1.0 : 0.25)
-                                    .scaleEffect(isCirclePulsing ? 1.2 : 0.8)
-                                
-                                Text("Generating...")
-                                    .opacity(isCirclePulsing ? 0.8 : 0.25)
-                                    .fontDesign(.rounded)
-                                    .fontWeight(.medium)
-                                
-                                
-                                Spacer()
-                            }
-                            .padding(.top)
-                            .padding(.leading)
-                            .onAppear {
-                                withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
-                                    isCirclePulsing.toggle()
-                                }
-                            }
-                            .onDisappear {
-                                isCirclePulsing = false
-                            }
-                        }
-                        
                         ForEach(Chat.shared.responseMessage, id: \.id) { response in
                             Text(response.text)
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -77,6 +50,26 @@ struct ChatView: View {
                                 .textSelection(.enabled)
                                 .tint(.white)
                         }.animation(.easeOut(duration: 0.3), value: Chat.shared.responseMessage.count)
+                        
+                        if isShimmerTextVisible {
+                            HStack(alignment: .top, spacing: 10) {
+                                ShimmerText(text: "Generating notes ...")
+                                    .fontDesign(.rounded)
+                                    .fontWeight(.medium)
+                                
+                                Spacer()
+                            }
+                            .padding(.top)
+                            .padding(.leading)
+                            .onAppear {
+                                withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                                    isTextShimmering.toggle()
+                                }
+                            }
+                            .onDisappear {
+                                isTextShimmering = false
+                            }
+                        }
                         
                         Spacer(minLength: keyboardHeight > 0 ? keyboardHeight + 150 : 135)
                         Color.clear.frame(height: 1).id("chat-bottom")
@@ -92,7 +85,7 @@ struct ChatView: View {
                         task = Task { @MainActor in
                             guard !Task.isCancelled else { return }
                             
-                            try? await Task.sleep(for: .milliseconds(300))
+                            try? await Task.sleep(for: .milliseconds(700))
                             proxy.scrollTo("chat-bottom", anchor: .bottom)
                             task = nil
                         }
@@ -250,15 +243,15 @@ struct ChatView: View {
                             let photos: [PhotosPickerItem] = selectedPhotos
                             Chat.sendChatMessage(userFile: fileUrls.first, context: context, selectedPhotos: photos)
                             isEmptyStateSeen = true
-                            isCircleVisible = true
-                            isCirclePulsing = true
+                            isShimmerTextVisible = true
+                            isTextShimmering = true
                             fileUrls.removeAll()
                             selectedPhotos.removeAll()
                             
                         }.onChange(of: Chat.shared.responseMessage.last?.text) { _, newValue in
                             if let presentText = newValue, !presentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                                isCircleVisible = false
-                                isCirclePulsing = false
+                                isShimmerTextVisible = false
+                                isTextShimmering = false
                             }
                         }
                     
@@ -323,8 +316,8 @@ struct ChatView: View {
                         Spacer()
                         Button {
                             isEmptyStateSeen = true
-                            isCircleVisible = true
-                            isCirclePulsing = true
+                            isShimmerTextVisible = true
+                            isTextShimmering = true
                             
                             let photos: [PhotosPickerItem] = selectedPhotos
                             Chat.sendChatMessage(userFile: fileUrls.first, context: context, selectedPhotos: photos)

--- a/Rep/UIComponents/MacHelperDirections.swift
+++ b/Rep/UIComponents/MacHelperDirections.swift
@@ -80,6 +80,23 @@ struct MacHelperDirections: View {
                     Image(systemName: "bell.badge")
                         .font(.system(size: 15, weight: .regular))
                 }
+                
+                let appStoreURL: URL = URL(string: "testing")!  //TODO: replace with app store url
+                ShareLink(item: appStoreURL) {
+                    ZStack {
+                        Capsule(style: .continuous)
+                            .fill(Color.intervalBlue)
+                            .frame(width: 145, height: 30)
+                            .glassEffect(.clear)
+                        
+                        HStack(spacing: 5) {
+                            Text("Mac Download")
+                            Image(systemName: "arrow.up.right")
+                        }
+                        .foregroundStyle(Color.kimchiLabs)
+                    }
+                }
+                .buttonStyle(.plain)
             }
             .font(.system(size: 14, weight: .regular, design: .rounded))
             .foregroundStyle(Color.mmDark)


### PR DESCRIPTION
## Summary

- Adds a shareable Mac download action to the desktop helper instructions.
- Makes generated chats, imported notes, and transcripts selectable as continuous multiline text with a white selection tint for easier copying.
- Improves chat streaming performance by throttling automatic scrolling and replaces the loading pulse with shimmer text positioned below the generated response, as well as removing MainActor closure and building a mini task manager in order to throttle the auto-scroll anchor 

## Note

- The Mac download URL is currently a placeholder and should be replaced with the App Store URL before release.
